### PR TITLE
Fix Issue with text color in language option matching its background.

### DIFF
--- a/src/components/ThemeMode/index.scss
+++ b/src/components/ThemeMode/index.scss
@@ -7,6 +7,9 @@
       -webkit-appearance: none;
       cursor: pointer;
     }
+    option {
+      color: black;
+    }
   }
 
   .theme-container {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/106925795/180620755-22584458-86c0-43c1-880f-fc6fa9c69fb6.png)

The fix is to color the text in select options black.